### PR TITLE
Add styling for 4 kts

### DIFF
--- a/site/polarplot.css
+++ b/site/polarplot.css
@@ -37,6 +37,11 @@ svg .axis text {
     fill: #fff;
 }
 
+.tws-4 {
+    stroke: #8c564b;
+    color: #8c564b;
+}
+
 .tws-6 {
     stroke: #1f77b4;
     color: #1f77b4;


### PR DESCRIPTION
The 2025 ORC Certificates include an extra wind speed: 4 kts. 
Generating new data files already adds this in the JSON files, but the UI needs a color for the new wind speed.

![Screenshot 2025-01-26 at 14-20-41 ORC sailboat data](https://github.com/user-attachments/assets/b5950c8d-aa02-4367-9ff0-09abb4c445f8)
